### PR TITLE
fix(ci): unblock PyPI publish and stabilize uv build backend version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          version: "0.12.0"
 
       - name: Build and Publish to PyPI
         run: |

--- a/packages/hundredandten-automation-engineadapter/pyproject.toml
+++ b/packages/hundredandten-automation-engineadapter/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]
 name = "hundredandten-automation-engineadapter"
-version = "0.0.7"
+version = "0.0.8"
 description = "Engine adapter for wiring automation strategies to the Hundred and Ten game engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-automation-naive/pyproject.toml
+++ b/packages/hundredandten-automation-naive/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]
 name = "hundredandten-automation-naive"
-version = "0.0.7"
+version = "0.0.8"
 description = "Naive strategy player for the game Hundred and Ten"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-automation-naive/pyproject.toml
+++ b/packages/hundredandten-automation-naive/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hundredandten-automation-naive"
-version = "0.0.6"
+version = "0.0.7"
 description = "Naive strategy player for the game Hundred and Ten"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-deck/pyproject.toml
+++ b/packages/hundredandten-deck/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]
 name = "hundredandten-deck"
-version = "0.0.4"
+version = "0.0.5"
 description = "Card domain primitives for the game Hundred and Ten"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-engine/pyproject.toml
+++ b/packages/hundredandten-engine/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]
 name = "hundredandten-engine"
-version = "0.0.8"
+version = "0.0.9"
 description = "An engine to play the game Hundred and Ten"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-state/pyproject.toml
+++ b/packages/hundredandten-state/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]
 name = "hundredandten-state"
-version = "0.0.7"
+version = "0.0.8"
 description = "Player observation layer for the game Hundred and Ten"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/hundredandten-testing/pyproject.toml
+++ b/packages/hundredandten-testing/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.12"]
+requires = ["uv_build>=0.11.32,<0.13"]
 build-backend = "uv_build"
 
 [project]

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,7 @@ test = [{ name = "hundredandten-testing", editable = "packages/hundredandten-tes
 
 [[package]]
 name = "hundredandten-automation-naive"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "packages/hundredandten-automation-naive" }
 dependencies = [
     { name = "hundredandten-deck" },

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "hundredandten-automation-engineadapter"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "packages/hundredandten-automation-engineadapter" }
 dependencies = [
     { name = "hundredandten-deck" },
@@ -192,7 +192,7 @@ test = [{ name = "hundredandten-testing", editable = "packages/hundredandten-tes
 
 [[package]]
 name = "hundredandten-automation-naive"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "packages/hundredandten-automation-naive" }
 dependencies = [
     { name = "hundredandten-deck" },
@@ -221,12 +221,12 @@ test = [
 
 [[package]]
 name = "hundredandten-deck"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "packages/hundredandten-deck" }
 
 [[package]]
 name = "hundredandten-engine"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "packages/hundredandten-engine" }
 dependencies = [
     { name = "hundredandten-deck" },
@@ -237,7 +237,7 @@ requires-dist = [{ name = "hundredandten-deck", editable = "packages/hundredandt
 
 [[package]]
 name = "hundredandten-state"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "packages/hundredandten-state" }
 dependencies = [
     { name = "hundredandten-deck" },


### PR DESCRIPTION
## Summary

- Main's `Publish` workflow has been failing since `hundredandten-automation-naive` changed (#184 fix/bid_too_high) without a version bump: `0.0.6` was already on PyPI, so rebuilding the same version now produces different wheel bytes and PyPI rejects it with a hash mismatch.
- Investigating also surfaced that `uv build` resolves a `uv_build` backend version to satisfy each package's `build-system.requires` pin, and embeds that resolved version in the wheel's `Generator` metadata. Every package's `<0.12` pin no longer matches the latest uv (0.12.0) that CI installs, which was only producing a warning today -- but widening that pin changes wheel bytes for every already-published package, not just the one that triggered the original failure.

## Changes

- Bump `hundredandten-automation-naive` `0.0.6` -> `0.0.7` (then `0.0.8`, see below) to get past the stale-hash failure.
- Widen `uv_build` pin from `<0.12` to `<0.13` across all six packages so CI's uv 0.12.0 satisfies the constraint (no more warning).
- Pin `publish.yaml`'s `setup-uv` step to exactly `version: "0.12.0"` so the release workflow always resolves a deterministic, matching build backend rather than floating to whatever uv ships next.
- Patch-bump every package the `Publish` workflow ships, since widening the pin changes their wheel bytes even with unchanged source: `deck` `0.0.4`->`0.0.5`, `engine` `0.0.8`->`0.0.9`, `state` `0.0.7`->`0.0.8`, `automation-naive` `0.0.7`->`0.0.8`, `automation-engineadapter` `0.0.7`->`0.0.8`.

## Verification

- Confirmed via PyPI JSON API that none of the new version numbers are already published.
- Built all five wheels locally with the widened pin -- no more `does not contain the current uv version` warning.
- `uv run pytest`: 203 passed.
- `uv run black .` / `uv run ruff check --fix`: clean.